### PR TITLE
Remove proteins with unknown taxon ID

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libsais64-rs/libsais"]
+	path = libsais64-rs/libsais
+	url = https://github.com/IlyaGrebnov/libsais.git
+	ignore = untracked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -132,6 +132,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.48",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,13 +188,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cdivsufsort"
-version = "2.0.0"
+name = "cexpr"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edefce019197609da416762da75bb000bbd2224b2d89a7e722c2296cbff79b8c"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
- "cc",
- "sacabase",
+ "nom",
 ]
 
 [[package]]
@@ -179,6 +201,17 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -226,7 +259,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -330,15 +363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "divsufsort"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e57e36c45fe0b4ef9bc690e53cce2f46dc193f7be3bc93bb7d23ca6dc1be820"
-dependencies = [
- "sacabase",
-]
-
-[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -433,6 +457,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +487,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +517,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +536,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -502,6 +556,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ae6d5de0472a582c6be43c392ba23e8ca59add069c8bd661f6b2a90690be3fb"
 dependencies = [
  "cmake",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "libsais64-rs"
+version = "0.1.0"
+dependencies = [
+ "bindgen",
 ]
 
 [[package]]
@@ -542,6 +613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +643,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -615,7 +702,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -658,6 +745,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,18 +780,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -764,6 +861,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,7 +876,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -783,21 +886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "sacabase"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9883fc3d6ce3d78bb54d908602f8bc1f7b5f983afe601dabe083009d86267a84"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -846,7 +940,7 @@ checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -859,6 +953,12 @@ dependencies = [
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "strsim"
@@ -918,11 +1018,10 @@ dependencies = [
 name = "suffixarray"
 version = "0.1.0"
 dependencies = [
- "cdivsufsort",
  "clap 4.4.8",
- "divsufsort",
  "get-size",
  "libdivsufsort-rs",
+ "libsais64-rs",
  "tsv-utils",
  "umgap",
 ]
@@ -949,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -968,7 +1067,7 @@ dependencies = [
  "fastrand",
  "redox_syscall",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1092,6 +1191,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1119,7 +1230,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -1128,13 +1248,28 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -1144,10 +1279,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1156,10 +1303,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1168,13 +1327,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ resolver = "2"
 members = [
     "suffixtree",
     "suffixarray",
-    "tsv-utils"
+    "tsv-utils",
+    "libsais64-rs"
 ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+### Requirements
+`clang` should be installed on the machine since it is used under the hood to create the C bindings in `libsais64-rs.  
+On Debian Linux this can be installed by executing
+```sh
+ sudo apt install clang
+```
+on MacOS this is part of the Xcode Command Line Tools.
+
+### Installation
+Clone this repository with the following command:
+```sh
+https://github.com/BramDevlaminck/Thesis_rust_implementations.git
+```
+and initialize the git submodules by executing
+```sh
+git submodule update --init --recursive
+```

--- a/libsais64-rs/Cargo.toml
+++ b/libsais64-rs/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libsais64-rs"
+version = "0.1.0"
+edition = "2021"
+build = "builder.rs"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+bindgen = "0.69.4"

--- a/libsais64-rs/builder.rs
+++ b/libsais64-rs/builder.rs
@@ -1,0 +1,72 @@
+use std::env;
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+use std::process::{Command, ExitStatus};
+
+#[derive(Debug)]
+struct CompileError<'a> {
+    command: &'a str,
+    exit_code: Option<i32>,
+}
+
+impl<'a> Display for CompileError<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let end_text = if let Some(code) = self.exit_code {
+            format!("with exit code {}", code)
+        } else {
+            "without exit code".to_string()
+        };
+        let text = format!("Command with name `{}` failed {}", self.command, end_text);
+        write!(f, "{}", text)
+    }
+}
+
+impl<'a> Error for CompileError<'a> {}
+
+fn exit_status_to_result(name: &str, exit_status: ExitStatus) -> Result<(), CompileError> {
+    match exit_status.success() {
+        true => Ok(()),
+        false => Err(CompileError {
+            command: name,
+            exit_code: exit_status.code(),
+        }),
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // compile the c library
+    exit_status_to_result(
+        "cmake",
+        Command::new("cmake")
+            .args(["-DCMAKE_BUILD_TYPE=\"Release\"", "libsais", "-Blibsais"])
+            .status()?,
+    )?;
+    exit_status_to_result(
+        "make",
+        Command::new("make").args(["-C", "libsais"]).status()?,
+    )?;
+
+    // link the c libsais library to rust
+    println!("cargo:rustc-link-search=native=libsais64-rs/libsais");
+    println!("cargo:rustc-link-lib=static=libsais");
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("libsais-wrapper.h")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        // Finish the builder and generate the bindings.
+        .generate()?;
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR")?);
+    bindings.write_to_file(out_path.join("bindings.rs"))?;
+
+    Ok(())
+}

--- a/libsais64-rs/libsais-wrapper.h
+++ b/libsais64-rs/libsais-wrapper.h
@@ -1,0 +1,4 @@
+#include "libsais/include/libsais64.h"
+
+
+int64_t libsais64(const uint8_t * T, int64_t * SA, int64_t n, int64_t fs, int64_t * freq);

--- a/libsais64-rs/src/lib.rs
+++ b/libsais64-rs/src/lib.rs
@@ -1,0 +1,27 @@
+// ignore errors because of different style in c code and import the c bindings
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+pub fn sais64(text: &[u8]) -> Option<Vec<i64>> {
+    let mut sa = vec![0; text.len()];
+    let exit_code = unsafe { libsais64(text.as_ptr(), sa.as_mut_ptr(), text.len() as i64, 0, std::ptr::null_mut()) };
+    if exit_code == 0 {
+        Some(sa)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{sais64};
+
+    #[test]
+    fn check_build_sa_with_libsais64() {
+        let text = "banana$";
+        let sa = sais64(text.as_bytes());
+        assert_eq!(sa, Some(vec![6, 5, 3, 1, 0, 4, 2]));
+    }
+}

--- a/suffixarray/Cargo.toml
+++ b/suffixarray/Cargo.toml
@@ -6,10 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cdivsufsort = "2.0.0"
 clap = { version = "4.4.8", features = ["derive"] }
-divsufsort = "2.0.0"
 get-size = "0.1.4"
 libdivsufsort-rs = "0.1.0"
 tsv-utils = { path = "../tsv-utils"}
 umgap = "1.0.0"
+libsais64-rs = {path = "../libsais64-rs"}

--- a/suffixarray/search_using_existing_index.pbs
+++ b/suffixarray/search_using_existing_index.pbs
@@ -4,7 +4,7 @@
 ### This script is designed to run on the Ghent university HPC                                        ###
 ###                                                                                                   ###
 ### how to use:                                                                                       ###
-### 1) load the rust module Rust/1.70.0-GCCcore-12.3.0 with `module load Rust/1.70.0-GCCcore-12.3.0`  ###
+### 1) load the rust module Rust/1.70.0-GCCcore-12.3.0 with `module load Rust/1.75.0-GCCcore-12.3.0`  ###
 ### 2) compile the code on the login node using `cargo build --release`                               ###
 ### 3) navigate the to folder of the binary (in `target/release`)                                     ###
 ### 4) submit the job to the queue with `qsub search_using_existing_index.pbs`                        ###

--- a/suffixarray/src/lib.rs
+++ b/suffixarray/src/lib.rs
@@ -69,25 +69,32 @@ pub struct Arguments {
 }
 
 pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
-    let start = SystemTime::now()
+    let start_reading_proteins_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards").as_nanos() as f64 * 1e-6;
-    let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
+        .expect("Time went backwards").as_nanos() as f64 * 1e-6;    let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
     println!("taxonomy calculator built");
 
     let proteins = get_proteins_from_database_file(&args.database_file, &*taxon_id_calculator);
+
     // construct the sequence that will be used to build the tree
     println!("read all proteins");
     let current = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards").as_nanos() as f64 * 1e-6;
-    println!("Time spent for reading: {}", current - start);
+    println!("Time spent for reading: {}", current - start_reading_proteins_ms);
 
     let sa = match &args.load_index {
         // load SA from file
         Some(index_file_name) => {
+            let start_loading_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards").as_nanos() as f64 * 1e-6;
             let (sample_rate, sa) = load_binary(index_file_name)?;
             args.sample_rate = sample_rate;
+            let end_loading_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("Time went backwards").as_nanos() as f64 * 1e-6;
+            println!("Loading the SA took {} ms and loading the proteins + SA took {} ms", end_loading_ms - start_loading_ms, end_loading_ms - start_reading_proteins_ms);
             // TODO: some kind of security check that the loaded database file and SA match
             sa
         },

--- a/suffixarray/src/lib.rs
+++ b/suffixarray/src/lib.rs
@@ -69,12 +69,19 @@ pub struct Arguments {
 }
 
 pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
+    let start = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards").as_nanos() as f64 * 1e-6;
     let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
     println!("taxonomy calculator built");
 
     let proteins = get_proteins_from_database_file(&args.database_file, &*taxon_id_calculator);
     // construct the sequence that will be used to build the tree
     println!("read all proteins");
+    let current = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards").as_nanos() as f64 * 1e-6;
+    println!("Time spent for reading: {}", current - start);
 
     let sa = match &args.load_index {
         // load SA from file

--- a/suffixarray/src/lib.rs
+++ b/suffixarray/src/lib.rs
@@ -69,7 +69,10 @@ pub struct Arguments {
 }
 
 pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
-    let proteins = get_proteins_from_database_file(&args.database_file);
+    let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
+    println!("taxonomy calculator built");
+
+    let proteins = get_proteins_from_database_file(&args.database_file, &*taxon_id_calculator);
     // construct the sequence that will be used to build the tree
     println!("read all proteins");
 
@@ -104,8 +107,6 @@ pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
         }
     };
 
-
-
     if let Some(output) = &args.output {
         println!("storing index to file {}", output);
         write_binary(args.sample_rate, &sa, &proteins.input_string, output).unwrap();
@@ -118,9 +119,6 @@ pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
         SuffixToProteinMappingStyle::Sparse => Box::new(SparseSuffixToProtein::new(&proteins.input_string)),
     };
     println!("mapping built");
-
-    let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
-    println!("taxonomy calculator built");
 
     // option that only builds the tree, but does not allow for querying (easy for benchmark purposes)
     if args.build_only {

--- a/suffixarray/src/lib.rs
+++ b/suffixarray/src/lib.rs
@@ -79,7 +79,8 @@ pub struct Arguments {
 pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
     let start_reading_proteins_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards").as_nanos() as f64 * 1e-6;    let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
+        .expect("Time went backwards").as_nanos() as f64 * 1e-6;
+    let taxon_id_calculator = TaxonIdCalculator::new(&args.taxonomy);
     println!("taxonomy calculator built");
 
     let proteins = get_proteins_from_database_file(&args.database_file, &*taxon_id_calculator);

--- a/suffixarray/src/lib.rs
+++ b/suffixarray/src/lib.rs
@@ -113,13 +113,6 @@ pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
         println!("Index written away");
     }
 
-    // build the right mapping index, use box to be able to store both types in this variable
-    let suffix_index_to_protein: Box<dyn SuffixToProteinIndex> = match args.suffix_to_protein_mapping {
-        SuffixToProteinMappingStyle::Dense => Box::new(DenseSuffixToProtein::new(&proteins.input_string)),
-        SuffixToProteinMappingStyle::Sparse => Box::new(SparseSuffixToProtein::new(&proteins.input_string)),
-    };
-    println!("mapping built");
-
     // option that only builds the tree, but does not allow for querying (easy for benchmark purposes)
     if args.build_only {
         return Ok(());
@@ -127,6 +120,13 @@ pub fn run(mut args: Arguments) -> Result<(), Box<dyn Error>> {
         eprintln!("search mode expected!");
         std::process::exit(1);
     }
+
+    // build the right mapping index, use box to be able to store both types in this variable
+    let suffix_index_to_protein: Box<dyn SuffixToProteinIndex> = match args.suffix_to_protein_mapping {
+        SuffixToProteinMappingStyle::Dense => Box::new(DenseSuffixToProtein::new(&proteins.input_string)),
+        SuffixToProteinMappingStyle::Sparse => Box::new(SparseSuffixToProtein::new(&proteins.input_string)),
+    };
+    println!("mapping built");
 
     let searcher = Searcher::new(&sa, args.sample_rate, suffix_index_to_protein.as_ref(), &proteins, &taxon_id_calculator);
     execute_search(searcher, &proteins, &args);

--- a/suffixarray/suffix_array.pbs
+++ b/suffixarray/suffix_array.pbs
@@ -32,7 +32,15 @@ module swap cluster/gallade
 folder=""
 prefix="$VSC_DATA_VO/bram/"
 
+# load Rust
+module load Rust/1.75.0-GCCcore-12.3.0
+
 # go to current working dir and execute
 cd $PBS_O_WORKDIR
+
+# compile
+cargo build --release
+
+# execute
 ./suffixarray -d "$prefix""$folder"uniprotKB_protein_database.tsv -t "$prefix"taxons.tsv --build-only --suffix-to-protein-mapping sparse -o "$prefix"uniprot_indexed
 # ./suffixarray -d "$prefix""$folder"protein_database.tsv -s "$prefix""$folder""$search_file" -t "$prefix"taxons.tsv -m all-occurrences

--- a/suffixarray/suffix_array.pbs
+++ b/suffixarray/suffix_array.pbs
@@ -4,7 +4,7 @@
 ### This script is designed to run on the Ghent university HPC                                        ###
 ###                                                                                                   ###
 ### how to use:                                                                                       ###
-### 1) load the rust module Rust/1.70.0-GCCcore-12.3.0 with `module load Rust/1.70.0-GCCcore-12.3.0`  ###
+### 1) load the rust module Rust/1.70.0-GCCcore-12.3.0 with `module load Rust/1.75.0-GCCcore-12.3.0`  ###
 ### 2) compile the code on the login node using `cargo build --release`                               ###
 ### 3) navigate the to folder of the binary (in `target/release`)                                     ###
 ### 4) submit the job to the queue with `qsub suffix_array.pbs`                                       ###

--- a/suffixtree/src/lib.rs
+++ b/suffixtree/src/lib.rs
@@ -115,14 +115,15 @@ fn handle_search_word(searcher: &mut Searcher, proteins: &Proteins, word: String
 
 /// Main run function that executes all the logic with the received arguments
 pub fn run(args: Arguments) {
-    let proteins = get_proteins_from_database_file(&args.database_file);
+    let tree_taxon_id_calculator = TreeTaxonIdCalculator::new(&args.taxonomy);
+
+    let proteins = get_proteins_from_database_file(&args.database_file, &tree_taxon_id_calculator);
     // construct the sequence that will be used to build the tree
     let data = &proteins.input_string;
 
     // build the tree
     let mut tree = Tree::new(data, UkkonenBuilder::new());
     // fill in the Taxon Ids in the tree using the LCA implementations from UMGAP
-    let tree_taxon_id_calculator = TreeTaxonIdCalculator::new(&args.taxonomy);
     tree_taxon_id_calculator.calculate_taxon_ids(&mut tree, &proteins.proteins);
 
     // print the taxon ids of the tree if flag set

--- a/suffixtree/src/tree_taxon_id_calculator.rs
+++ b/suffixtree/src/tree_taxon_id_calculator.rs
@@ -1,6 +1,6 @@
 use umgap::taxon::TaxonId;
 
-use tsv_utils::taxon_id_calculator::TaxonIdCalculator;
+use tsv_utils::taxon_id_calculator::{TaxonIdCalculator, TaxonIdVerifier};
 
 use crate::Protein;
 use crate::tree::{NodeIndex, Nullable, Tree};
@@ -134,6 +134,12 @@ impl TreeTaxonIdCalculator {
     /// Calculates the aggregate of a vector containing TaxonIds
     fn get_aggregate(&self, ids: Vec<TaxonId>) -> TaxonId {
         self.taxon_id_calculator.get_aggregate(ids)
+    }
+}
+
+impl TaxonIdVerifier for TreeTaxonIdCalculator {
+    fn taxon_id_exists(&self, id: TaxonId) -> bool {
+        self.taxon_id_calculator.taxon_id_exists(id)
     }
 }
 

--- a/tsv-utils/src/taxon_id_calculator.rs
+++ b/tsv-utils/src/taxon_id_calculator.rs
@@ -4,6 +4,13 @@ use umgap::taxon::{TaxonId, TaxonList, TaxonTree};
 pub struct TaxonIdCalculator {
     snapping: Vec<Option<TaxonId>>,
     aggregator: Box<dyn Aggregator>,
+    taxon_list: TaxonList
+}
+
+pub trait TaxonIdVerifier {
+
+    fn taxon_id_exists(&self, id: TaxonId) -> bool;
+
 }
 
 impl TaxonIdCalculator {
@@ -18,6 +25,7 @@ impl TaxonIdCalculator {
         Box::new(Self {
             snapping,
             aggregator: Box::new(aggregator),
+            taxon_list: by_id
         })
     }
 
@@ -30,5 +38,12 @@ impl TaxonIdCalculator {
     pub fn get_aggregate(&self, ids: Vec<TaxonId>) -> TaxonId {
         let count = agg::count(ids.into_iter().map(|it| (it, 1.0)));
         self.aggregator.aggregate(&count).unwrap_or_else(|_| panic!("Could not aggregate following taxon ids: {:?}", &count))
+    }
+
+}
+
+impl TaxonIdVerifier for TaxonIdCalculator {
+    fn taxon_id_exists(&self, id: TaxonId) -> bool {
+        self.taxon_list.get(id).is_some()
     }
 }


### PR DESCRIPTION
Filter away proteins with a taxon id that is unknown in the used taxonomy during SA build.
This is needed since calculating the LCA fails when 1 or more taxon ids is unknown and Unipept already ignores those proteins in the current implementation.
